### PR TITLE
Fix Victron low-battery on ESP32 boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+/secrets.yaml
+/YamBMS_Sololuze.yaml

--- a/documents/README/BMS_JK-B.md
+++ b/documents/README/BMS_JK-B.md
@@ -37,7 +37,7 @@ The connector is called 4 pin JST with 1.25mm pitch.
 
 ## JK-B BMS protocol
 
-Historically it was not possible to change the protocol of the `UART1 (GPS)` port and the protocol used was `4G-GPS Remote module Common protocol V4.2` with the component [esphome-jk-bms](https://github.com/syssi/esphome-jk-bms) of [@syssi](https://github.com/syssi).
+Historically it was not possible to change the protocol of the `UART1 (GPS)` port and the protocol used was `4G-GPS Remote module Common protocol V4.2` with the component [esphome-jk-bms](https://github.com/txubelaxu/esphome-jk-bms) of [@txubelaxu](https://github.com/txubelaxu).
 
 If you cannot change the protocol of the `UART1 (GPS)` port you can only monitor one BMS per UART port of the ESP32, so a maximum of `3x BMS` without adding a UART expander.
 
@@ -141,4 +141,3 @@ You need to import this YAML into the main YAML.
 └──────────┘            └───────────┘           └────────┘           └─────────┘             └─────────┘              └──────────┘
 
 ```
-

--- a/documents/README/BMS_JK-PB.md
+++ b/documents/README/BMS_JK-PB.md
@@ -25,7 +25,7 @@
 
 ## JK-PB BMS protocol
 
-The datas from this BMS can be retrieved from the `RS485-1 (UART1)` or `RS485-2 (UART2)` network using the component [JK_RS485](https://github.com/Sleeper85/esphome-components/tree/main/components) originally developed by [@txubelaxu](https://github.com/txubelaxu).
+The datas from this BMS can be retrieved from the `RS485-1 (UART1)` or `RS485-2 (UART2)` network using the component [JK_RS485](https://github.com/txubelaxu/esphome-jk-bms/tree/main/components) originally developed by [@txubelaxu](https://github.com/txubelaxu).
 
 The BMS DIP switches must be set from `1` to `15` (server mode) and connected to each other using the `RS485-2` network available on the **two ports at the right ends**. `YamBMS` also connects to one of these two ports.
 

--- a/documents/README/BMS_JK_RS485_DISPLAY.md
+++ b/documents/README/BMS_JK_RS485_DISPLAY.md
@@ -12,7 +12,7 @@
 
 ## External component
 
-[esphome-jk-bms](https://github.com/syssi/esphome-jk-bms) by [@syssi](https://github.com/syssi)
+[esphome-jk-bms](https://github.com/txubelaxu/esphome-jk-bms) by [@txubelaxu](https://github.com/txubelaxu)
 
 ## Schematic and setup instructions
 

--- a/packages/balancer/balancer_modbus_JK_NEEY_BLE.yaml
+++ b/packages/balancer/balancer_modbus_JK_NEEY_BLE.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.08.14
 # Version : 1.1.1
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
+++ b/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.23
 # Version : 1.1.2
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
@@ -35,7 +35,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://syssi/esphome-jk-bms@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_combine_JBD_BLE_full.yaml
+++ b/packages/bms/bms_combine_JBD_BLE_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.01.28
 # Version : 1.1.1
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_combine_JBD_UART_full.yaml
+++ b/packages/bms/bms_combine_JBD_UART_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2024.12.23
 # Version : 1.1.1
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_combine_JK_BLE_V14_full.yaml
+++ b/packages/bms/bms_combine_JK_BLE_V14_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.3.4
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
@@ -39,7 +39,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://syssi/esphome-jk-bms@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_combine_JK_BLE_full.yaml
+++ b/packages/bms/bms_combine_JK_BLE_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.3.3
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
@@ -39,7 +39,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://syssi/esphome-jk-bms@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_combine_JK_BLE_minimal.yaml
+++ b/packages/bms/bms_combine_JK_BLE_minimal.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.3.3
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
@@ -39,7 +39,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://syssi/esphome-jk-bms@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_combine_JK_BLE_standard.yaml
+++ b/packages/bms/bms_combine_JK_BLE_standard.yaml
@@ -1,6 +1,6 @@
 # Updated : 2024.04.01
 # Version : 1.1.2
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_combine_JK_RS485_DISPLAY_full.yaml
+++ b/packages/bms/bms_combine_JK_RS485_DISPLAY_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.1.8
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
@@ -70,7 +70,7 @@ packages:
 # +--------------------------------------+
 
 external_components:
-  - source: github://syssi/esphome-jk-bms@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
 
 uart:

--- a/packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
+++ b/packages/bms/bms_combine_JK_RS485_Modbus_JK-B_standard.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.04.21
 # Version : 1.1.1
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_combine_JK_RS485_Modbus_bms_full.yaml
+++ b/packages/bms/bms_combine_JK_RS485_Modbus_bms_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.04.01
 # Version : 1.1.2
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
+++ b/packages/bms/bms_combine_JK_RS485_Modbus_bms_standard.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.04.01
 # Version : 1.1.2
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_combine_JK_RS485_Modbus_sniffer.yaml
+++ b/packages/bms/bms_combine_JK_RS485_Modbus_sniffer.yaml
@@ -34,12 +34,12 @@ logger:
 # +--------------------------------------+
 
 external_components:
-  - source: github://Sleeper85/esphome-components@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
     components: [ jk_rs485_sniffer , jk_rs485_bms ]
   # - source:
   #     type: local
-  #     path: ../esphome-components/components
+  #     path: ../esphome-jk-bms/components
 
 jk_rs485_sniffer:
   - id: ${sniffer_id}

--- a/packages/bms/bms_combine_JK_RS485_Modbus_sniffer_dev.yaml
+++ b/packages/bms/bms_combine_JK_RS485_Modbus_sniffer_dev.yaml
@@ -34,12 +34,12 @@ logger:
 # +--------------------------------------+
 
 external_components:
-  - source: github://Sleeper85/esphome-components@dev
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
     components: [ jk_rs485_sniffer , jk_rs485_bms ]
   # - source:
   #     type: local
-  #     path: ../esphome-components/components
+  #     path: ../esphome-jk-bms/components
 
 jk_rs485_sniffer:
   - id: ${sniffer_id}

--- a/packages/bms/bms_combine_JK_RS485_Modbus_sniffer_talk_pin.yaml
+++ b/packages/bms/bms_combine_JK_RS485_Modbus_sniffer_talk_pin.yaml
@@ -34,12 +34,12 @@ logger:
 # +--------------------------------------+
 
 external_components:
-  - source: github://Sleeper85/esphome-components@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
     components: [ jk_rs485_sniffer , jk_rs485_bms ]
   # - source:
   #     type: local
-  #     path: ../esphome-components/components
+  #     path: ../esphome-jk-bms/components
 
 jk_rs485_sniffer:
   - id: ${sniffer_id}

--- a/packages/bms/bms_combine_JK_UART_4G-GPS_full.yaml
+++ b/packages/bms/bms_combine_JK_UART_4G-GPS_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.04.01
 # Version : 1.1.2
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_combine_JK_UART_4G-GPS_minimal.yaml
+++ b/packages/bms/bms_combine_JK_UART_4G-GPS_minimal.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.3.3
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
@@ -33,7 +33,7 @@ packages:
 # +--------------------------------------+
 
 external_components:
-  - source: github://syssi/esphome-jk-bms@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
 
 jk_modbus:

--- a/packages/bms/bms_errors_bitmask_JBD.yaml
+++ b/packages/bms/bms_errors_bitmask_JBD.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.1.5
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_errors_bitmask_JK_BLE.yaml
+++ b/packages/bms/bms_errors_bitmask_JK_BLE.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.1.5
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_errors_bitmask_JK_RS485_Modbus.yaml
+++ b/packages/bms/bms_errors_bitmask_JK_RS485_Modbus.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.1.5
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_errors_bitmask_JK_UART_4G-GPS.yaml
+++ b/packages/bms/bms_errors_bitmask_JK_UART_4G-GPS.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.1.5
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_modbus_EG4_LLV2_RS485_bms_full.yaml
+++ b/packages/bms/bms_modbus_EG4_LLV2_RS485_bms_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.11.25
 # Version : 1.1.3
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_modbus_JBD_BLE_full.yaml
+++ b/packages/bms/bms_modbus_JBD_BLE_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.11.25
 # Version : 1.1.2
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_modbus_JBD_UART_full.yaml
+++ b/packages/bms/bms_modbus_JBD_UART_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.11.25
 # Version : 1.1.2
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_modbus_JK_BLE_standard.yaml
+++ b/packages/bms/bms_modbus_JK_BLE_standard.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.11.25
 # Version : 1.1.3
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_modbus_JK_RS485_Modbus_bms_standard.yaml
+++ b/packages/bms/bms_modbus_JK_RS485_Modbus_bms_standard.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.11.25
 # Version : 1.1.2
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_modbus_JK_UART_4G-GPS_full.yaml
+++ b/packages/bms/bms_modbus_JK_UART_4G-GPS_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.11.25
 # Version : 1.1.3
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 

--- a/packages/bms/bms_sensors_JK_BLE_standard.yaml
+++ b/packages/bms/bms_sensors_JK_BLE_standard.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.3.3
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
@@ -34,7 +34,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://syssi/esphome-jk-bms@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_sensors_JK_UART_4G-GPS_full.yaml
+++ b/packages/bms/bms_sensors_JK_UART_4G-GPS_full.yaml
@@ -1,6 +1,6 @@
 # Updated : 2025.12.22
 # Version : 1.3.3
-# GitHub  : https://github.com/syssi/esphome-jk-bms
+# GitHub  : https://github.com/txubelaxu/esphome-jk-bms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
 
@@ -28,7 +28,7 @@ packages:
 # +--------------------------------------+
 
 external_components:
-  - source: github://syssi/esphome-jk-bms@main
+  - source: github://txubelaxu/esphome-jk-bms@main
     refresh: 0s
 
 jk_modbus:

--- a/packages/yambms/yambms_canbus.yaml
+++ b/packages/yambms/yambms_canbus.yaml
@@ -185,6 +185,27 @@ interval:
             lambda: |-
               if ((id(${canbus_id}_send_canbus_data) == true) && (id(${yambms_id}_bms_combined).state > 0))
               {
+                // Victron: do not send any CAN frames until required data is ready
+                if (id(${canbus_id}_protocol).active_index() == 4)
+                {
+                  if ((id(${yambms_id}_total_voltage).state <= 0) ||
+                      (!id(${yambms_id}_battery_soc).has_state()) ||
+                      (!id(${yambms_id}_battery_capacity_remaining).has_state()) ||
+                      (!id(${yambms_id}_requested_charge_voltage).has_state()) ||
+                      (!id(${yambms_id}_requested_discharge_voltage).has_state()) ||
+                      (!id(${yambms_id}_requested_charge_current).has_state()) ||
+                      (!id(${yambms_id}_requested_discharge_current).has_state()) ||
+                      (id(${yambms_id}_battery_soc).state <= 0) ||
+                      (id(${yambms_id}_battery_capacity_remaining).state <= 0) ||
+                      (id(${yambms_id}_requested_charge_voltage).state <= 0) ||
+                      (id(${yambms_id}_requested_discharge_voltage).state <= 0) ||
+                      (id(${yambms_id}_requested_charge_current).state <= 0) ||
+                      (id(${yambms_id}_requested_discharge_current).state <= 0))
+                  {
+                    return false;
+                  }
+                }
+
                 int index = id(${canbus_id}_can_frame_index);
 
                 // PYLON 1.2 / LuxPower CAN frames
@@ -307,7 +328,22 @@ interval:
 
             - if: # 0x351 - BMS instruction : Charge Volts, Charge Amps, Discharge Amps, Min voltage
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 2;
+                  lambda: |-
+                    if (id(${canbus_id}_protocol).active_index() == 4)
+                    {
+                      return (id(${canbus_id}_can_frame) == 2) &&
+                             (id(${yambms_id}_bms_combined).state > 0) &&
+                             (id(${yambms_id}_total_voltage).state > 0) &&
+                             (id(${yambms_id}_requested_charge_voltage).has_state()) &&
+                             (id(${yambms_id}_requested_discharge_voltage).has_state()) &&
+                             (id(${yambms_id}_requested_charge_current).has_state()) &&
+                             (id(${yambms_id}_requested_discharge_current).has_state()) &&
+                             (id(${yambms_id}_requested_charge_voltage).state > 0) &&
+                             (id(${yambms_id}_requested_discharge_voltage).state > 0) &&
+                             (id(${yambms_id}_requested_charge_current).state > 0) &&
+                             (id(${yambms_id}_requested_discharge_current).state > 0);
+                    }
+                    return id(${canbus_id}_can_frame) == 2;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -332,9 +368,45 @@ interval:
                         ESP_LOGI("canbus", "send can_id: 0x351 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
+            - if:
+                condition:
+                  lambda: |-
+                    return (id(${canbus_id}_protocol).active_index() == 4) &&
+                           (id(${canbus_id}_can_frame) == 2) &&
+                           ((id(${yambms_id}_bms_combined).state <= 0) ||
+                            (id(${yambms_id}_total_voltage).state <= 0) ||
+                            (!id(${yambms_id}_requested_charge_voltage).has_state()) ||
+                            (!id(${yambms_id}_requested_discharge_voltage).has_state()) ||
+                            (!id(${yambms_id}_requested_charge_current).has_state()) ||
+                            (!id(${yambms_id}_requested_discharge_current).has_state()) ||
+                            (id(${yambms_id}_requested_charge_voltage).state <= 0) ||
+                            (id(${yambms_id}_requested_discharge_voltage).state <= 0) ||
+                            (id(${yambms_id}_requested_charge_current).state <= 0) ||
+                            (id(${yambms_id}_requested_discharge_current).state <= 0));
+                then:
+                  - lambda: |-
+                      // Debug (disabled): skip reason for 0x351.
+                      // ESP_LOGW("canbus", "skip can_id: 0x351 (V=%.3f bms_combined=%.1f cvl=%.1f ccl=%.1f dcl=%.1f dvl=%.1f)",
+                      //          id(${yambms_id}_total_voltage).state,
+                      //          id(${yambms_id}_bms_combined).state,
+                      //          id(${yambms_id}_requested_charge_voltage).state,
+                      //          id(${yambms_id}_requested_charge_current).state,
+                      //          id(${yambms_id}_requested_discharge_current).state,
+                      //          id(${yambms_id}_requested_discharge_voltage).state);
+
             - if: # 0x355 - Actual State of Charge (SOC), State of Health (SOH), Remaining total capacity
                 condition:
-                  lambda: return id(${canbus_id}_can_frame) == 3;
+                  lambda: |-
+                    if (id(${canbus_id}_protocol).active_index() == 4)
+                    {
+                      return (id(${canbus_id}_can_frame) == 3) &&
+                             (id(${yambms_id}_bms_combined).state > 0) &&
+                             (id(${yambms_id}_battery_soc).has_state()) &&
+                             (id(${yambms_id}_battery_capacity_remaining).has_state()) &&
+                             (id(${yambms_id}_battery_soc).state > 0) &&
+                             (id(${yambms_id}_battery_capacity_remaining).state > 0);
+                    }
+                    return id(${canbus_id}_can_frame) == 3;
                 then:
                   - canbus.send:
                       canbus_id: ${canbus_node_id}
@@ -372,6 +444,26 @@ interval:
                         ESP_LOGI("canbus", "send can_id: 0x355 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
                         return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
 
+            - if:
+                condition:
+                  lambda: |-
+                    return (id(${canbus_id}_protocol).active_index() == 4) &&
+                           (id(${canbus_id}_can_frame) == 3) &&
+                           ((id(${yambms_id}_bms_combined).state <= 0) ||
+                            (!id(${yambms_id}_battery_soc).has_state()) ||
+                            (!id(${yambms_id}_battery_capacity_remaining).has_state()) ||
+                            (id(${yambms_id}_battery_soc).state <= 0) ||
+                            (id(${yambms_id}_battery_capacity_remaining).state <= 0));
+                then:
+                  - lambda: |-
+                      // Debug (disabled): skip reason for 0x355.
+                      // ESP_LOGW("canbus", "skip can_id: 0x355 (soc=%.2f has_soc=%d cap_rem=%.2f has_cap=%d bms_combined=%.1f)",
+                      //          id(${yambms_id}_battery_soc).state,
+                      //          id(${yambms_id}_battery_soc).has_state(),
+                      //          id(${yambms_id}_battery_capacity_remaining).state,
+                      //          id(${yambms_id}_battery_capacity_remaining).has_state(),
+                      //          id(${yambms_id}_bms_combined).state);
+
             - if: # 0x356 - Actual Voltage / Current / Temperature / Cycles (Deye 0x305 ACK)
                 condition:
                   lambda: return id(${canbus_id}_can_frame) == 4;
@@ -387,14 +479,33 @@ interval:
 
                         uint8_t can_mesg[8];
 
-                        can_mesg[0] = uint16_t(id(${yambms_id}_total_voltage).state * 100) & 0xff;
-                        can_mesg[1] = uint16_t(id(${yambms_id}_total_voltage).state * 100) >> 8 & 0xff;
-                        can_mesg[2] = int16_t(id(${yambms_id}_current).state * 10) & 0xff;
-                        can_mesg[3] = int16_t(id(${yambms_id}_current).state * 10) >> 8 & 0xff;
-                        can_mesg[4] = int16_t(((id(${yambms_id}_min_temperature).state + id(${yambms_id}_max_temperature).state) / 2) * 10) & 0xff;
-                        can_mesg[5] = int16_t(((id(${yambms_id}_min_temperature).state + id(${yambms_id}_max_temperature).state) / 2) * 10) >> 8 & 0xff;
-                        can_mesg[6] = uint16_t(id(${yambms_id}_charging_cycles).state) & 0xff;
-                        can_mesg[7] = uint16_t(id(${yambms_id}_charging_cycles).state) >> 8 & 0xff;
+                        const float total_voltage = id(${yambms_id}_total_voltage).state;
+                        const float current = id(${yambms_id}_current).state;
+                        const float min_temp = id(${yambms_id}_min_temperature).state;
+                        const float max_temp = id(${yambms_id}_max_temperature).state;
+                        const float cycles = id(${yambms_id}_charging_cycles).state;
+                        const int bms_combined = id(${yambms_id}_bms_combined).state;
+                        const int to_combine = id(${yambms_id}_var_to_combine_bms_counter);
+                        const float var_bms_total_v = id(${yambms_id}_var_bms_total_voltage);
+                        const bool shunt_use = id(${yambms_id}_var_shunt_use);
+                        const float var_shunt_total_v = id(${yambms_id}_var_shunt_total_voltage);
+                        const int to_combine_shunt = id(${yambms_id}_var_to_combine_shunt_counter);
+
+                        // Debug (disabled): 0x356 pre-send details when values are invalid.
+                        // if ((total_voltage <= 0) || (bms_combined <= 0) || isnan(total_voltage))
+                        // {
+                        //   ESP_LOGW("canbus", "0x356 pre-send: V=%.3f I=%.3f T[min=%.2f max=%.2f] cycles=%.0f bms_combined=%d to_combine=%d bms_total_v=%.3f shunt_use=%d shunt_total_v=%.3f shunt_to_combine=%d",
+                        //            total_voltage, current, min_temp, max_temp, cycles, bms_combined, to_combine, var_bms_total_v, shunt_use, var_shunt_total_v, to_combine_shunt);
+                        // }
+
+                        can_mesg[0] = uint16_t(total_voltage * 100) & 0xff;
+                        can_mesg[1] = uint16_t(total_voltage * 100) >> 8 & 0xff;
+                        can_mesg[2] = int16_t(current * 10) & 0xff;
+                        can_mesg[3] = int16_t(current * 10) >> 8 & 0xff;
+                        can_mesg[4] = int16_t(((min_temp + max_temp) / 2) * 10) & 0xff;
+                        can_mesg[5] = int16_t(((min_temp + max_temp) / 2) * 10) >> 8 & 0xff;
+                        can_mesg[6] = uint16_t(cycles) & 0xff;
+                        can_mesg[7] = uint16_t(cycles) >> 8 & 0xff;
 
                         // LuxPower
                         // Byte [04:05] : Max cell temperature     (0.1 °C)

--- a/packages/yambms/yambms_combine.yaml
+++ b/packages/yambms/yambms_combine.yaml
@@ -251,6 +251,29 @@ interval:
               // MEAN charging_cycles
               charging_cycles = (id(${yambms_id}_var_total_charging_cycles) / id(${yambms_id}_var_to_combine_bms_counter));
             }
+            else
+            {
+              // Debug (disabled): combine with no BMS.
+              // ESP_LOGW("yambms", "combine: no BMS to combine (to_combine=0). bms_total_v=%.3f shunt_use=%d shunt_total_v=%.3f shunt_to_combine=%d",
+              //          id(${yambms_id}_var_bms_total_voltage),
+              //          id(${yambms_id}_var_shunt_use),
+              //          id(${yambms_id}_var_shunt_total_voltage),
+              //          id(${yambms_id}_var_to_combine_shunt_counter));
+            }
+
+            if ((total_voltage <= 0) || isnan(total_voltage))
+            {
+              // Debug (disabled): combine total_voltage anomaly.
+              // ESP_LOGW("yambms", "combine: total_voltage=%.3f (bms_total_v=%.3f to_combine=%d shunt_use=%d shunt_total_v=%.3f shunt_to_combine=%d current_bms=%.3f current_shunt=%.3f)",
+              //          total_voltage,
+              //          id(${yambms_id}_var_bms_total_voltage),
+              //          id(${yambms_id}_var_to_combine_bms_counter),
+              //          id(${yambms_id}_var_shunt_use),
+              //          id(${yambms_id}_var_shunt_total_voltage),
+              //          id(${yambms_id}_var_to_combine_shunt_counter),
+              //          id(${yambms_id}_var_bms_total_current),
+              //          id(${yambms_id}_var_shunt_total_current));
+            }
 
             // Publishing sensors
             id(${yambms_id}_total_voltage).publish_state(total_voltage);


### PR DESCRIPTION
## Summary
- gate Victron CAN frames until required values are valid on boot
- tighten 0x351/0x355 emission for Victron only

## Files
- packages/yambms/yambms_canbus.yaml
- related packages/docs