### PR TITLE
Adjust JK docs and BLE/display packages attribution

### DIFF
--- a/documents/README/BMS_JK-B.md
+++ b/documents/README/BMS_JK-B.md
@@ -37,7 +37,7 @@ The connector is called 4 pin JST with 1.25mm pitch.
 
 ## JK-B BMS protocol
 
-Historically it was not possible to change the protocol of the `UART1 (GPS)` port and the protocol used was `4G-GPS Remote module Common protocol V4.2` with the component [esphome-jk-bms](https://github.com/txubelaxu/esphome-jk-bms) of [@txubelaxu](https://github.com/txubelaxu).
+Historically it was not possible to change the protocol of the `UART1 (GPS)` port and the protocol used was `4G-GPS Remote module Common protocol V4.2` with the component [esphome-jk-bms](https://github.com/syssi/esphome-jk-bms) of [@syssi](https://github.com/syssi).
 
 If you cannot change the protocol of the `UART1 (GPS)` port you can only monitor one BMS per UART port of the ESP32, so a maximum of `3x BMS` without adding a UART expander.
 

--- a/documents/README/BMS_JK_RS485_DISPLAY.md
+++ b/documents/README/BMS_JK_RS485_DISPLAY.md
@@ -12,7 +12,7 @@
 
 ## External component
 
-[esphome-jk-bms](https://github.com/txubelaxu/esphome-jk-bms) by [@txubelaxu](https://github.com/txubelaxu)
+[esphome-jk-bms](https://github.com/syssi/esphome-jk-bms) by [@syssi](https://github.com/syssi)
 
 ## Schematic and setup instructions
 

--- a/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
+++ b/packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
@@ -35,7 +35,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://txubelaxu/esphome-jk-bms@main
+  - source: github://syssi/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_combine_JK_BLE_V14_full.yaml
+++ b/packages/bms/bms_combine_JK_BLE_V14_full.yaml
@@ -39,7 +39,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://txubelaxu/esphome-jk-bms@main
+  - source: github://syssi/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_combine_JK_BLE_full.yaml
+++ b/packages/bms/bms_combine_JK_BLE_full.yaml
@@ -39,7 +39,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://txubelaxu/esphome-jk-bms@main
+  - source: github://syssi/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_combine_JK_BLE_minimal.yaml
+++ b/packages/bms/bms_combine_JK_BLE_minimal.yaml
@@ -39,7 +39,7 @@ ota:
 # +--------------------------------------+
 
 external_components:
-  - source: github://txubelaxu/esphome-jk-bms@main
+  - source: github://syssi/esphome-jk-bms@main
     refresh: 0s
 
 esp32_ble_tracker:

--- a/packages/bms/bms_combine_JK_RS485_DISPLAY_full.yaml
+++ b/packages/bms/bms_combine_JK_RS485_DISPLAY_full.yaml
@@ -70,7 +70,7 @@ packages:
 # +--------------------------------------+
 
 external_components:
-  - source: github://txubelaxu/esphome-jk-bms@main
+  - source: github://syssi/esphome-jk-bms@main
     refresh: 0s
 
 uart:

--- a/packages/bms/bms_combine_JK_UART_4G-GPS_minimal.yaml
+++ b/packages/bms/bms_combine_JK_UART_4G-GPS_minimal.yaml
@@ -33,7 +33,7 @@ packages:
 # +--------------------------------------+
 
 external_components:
-  - source: github://txubelaxu/esphome-jk-bms@main
+  - source: github://syssi/esphome-jk-bms@main
     refresh: 0s
 
 jk_modbus:


### PR DESCRIPTION
## Summary
- point JK docs and BLE/display package headers to syssi repo where txubelaxu components are not used

## Files
- documents/README/BMS_JK-B.md
- documents/README/BMS_JK_RS485_DISPLAY.md
- packages/balancer/balancer_sensors_JK_NEEY_BLE.yaml
- packages/bms/bms_combine_JK_BLE_V14_full.yaml
- packages/bms/bms_combine_JK_BLE_full.yaml
- packages/bms/bms_combine_JK_BLE_minimal.yaml
- packages/bms/bms_combine_JK_RS485_DISPLAY_full.yaml
- packages/bms/bms_combine_JK_UART_4G-GPS_minimal.yaml