### PR TITLE
Fix Freenove MCP2515 defaults

### DIFF
--- a/packages/board/board_ESP32-S3_freenove_esp32_s3_wroom.yaml
+++ b/packages/board/board_ESP32-S3_freenove_esp32_s3_wroom.yaml
@@ -1,5 +1,5 @@
-# Updated : 2026.01.14
-# Version : 1.3.2
+# Updated : 2026.01.24
+# Version : 1.1.1
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -19,7 +19,7 @@
 
 substitutions:
   board_chip: "ESP32-S3"
-  board_name: "DevKitC-1"
+  board_name: "Freenove"
   # Interfaces GPIOs
   # uart_esp_1
   tx_pin_1: '17'
@@ -33,19 +33,16 @@ substitutions:
   # canbus_esp32_can
   tx_pin_4: '38'
   rx_pin_4: '39'
-#  # canbus_mcp2515
-#  spi_mosi_pin: '10'
-#  spi_miso_pin: '11'
-#  spi_clk_pin: '12'
-#  mcp2515_cs_pin: '9'
+  # canbus_mcp2515
   # talk_pin
   talk_pin: '8' # ESP32: 4, ESP32-S3: 8, ESP32-C3: 10
 
-  # canbus_mcp2515  (contiguos y en orden: CS, SCK, MOSI, MISO)
-  mcp2515_cs_pin:  '9'   # CS
-  spi_clk_pin:     '10'  # SCK
-  spi_mosi_pin:    '11'  # MOSI
-  spi_miso_pin:    '12'  # MISO
+  # canbus_mcp2515 (contiguous pins in board order: CS, SCK, MOSI, MISO)
+  # Adjust to the default SPI GPIOs if your wiring follows that order.
+  mcp2515_cs_pin: '9'   # CS
+  spi_clk_pin: '10'     # SCK
+  spi_mosi_pin: '11'    # MOSI
+  spi_miso_pin: '12'    # MISO
 
 
 packages:

--- a/packages/board/board_options_itf_canbus_mcp2515.yaml
+++ b/packages/board/board_options_itf_canbus_mcp2515.yaml
@@ -1,5 +1,5 @@
-# Updated : 2025.09.12
-# Version : 1.1.4
+# Updated : 2026.01.24
+# Version : 1.1.5
 # GitHub  : https://github.com/Sleeper85/esphome-yambms
 
 # YamBMS ( Yet another multi-BMS Merging Solution )
@@ -22,6 +22,7 @@
 substitutions:
   mcp2515_canbus_id: '2'
   mcp2515_canbus_bitrate: '500kbps'
+  canbus_clock: '8MHz'
 
 spi:
   - id: mcp2515_spi
@@ -37,4 +38,4 @@ canbus:
     cs_pin: ${mcp2515_cs_pin}
     can_id: ${mcp2515_canbus_id}
     bit_rate: ${mcp2515_canbus_bitrate}
-    clock: ${canbus_clock}               #8MHZ was default, but most of boards has 16MHZ crystal
+    clock: ${canbus_clock} # Default MCP2515 clock is 8MHz; many boards use 16MHz.


### PR DESCRIPTION
## Summary
- add default canbus_clock substitution for MCP2515
- clean Freenove ESP32-S3 board substitutions and metadata